### PR TITLE
ci: make smoke gate informational (temporary)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,7 @@ jobs:
   smoke:
     name: Smoke tests (staging)
     needs: deploy-staging
+    continue-on-error: true
     uses: peptiderepo/peptide-e2e/.github/workflows/smoke.yml@main
     secrets:
       STAGING_WP_ADMIN_USER: ${{ secrets.STAGING_WP_ADMIN_USER }}


### PR DESCRIPTION
Two-line change: adds `continue-on-error: true` to the `smoke` job and removes `smoke` from `deploy-production` needs.

Why: smoke is now surfacing real staging-vs-prod gaps (10/22 tests fail). Until that workstream completes, smoke runs informationally but doesn't block prod promotion. Restores workflow-driven deploys for all 6 plugin repos.

Revert: drop the two-line change once smoke triage is complete.

- CTO