### PR TITLE
fix: PHP 8.3 TypeError on Articles admin page (v2.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Peptide News Plugin are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning: [Semantic Versioning](https://semver.org/).
 
+## [2.5.1] - 2026-06-17
+
+### Fixed
+- PHP 8.3 `TypeError` on Articles admin page: `number_format()` rejects the numeric string returned by `$wpdb->get_var()`. Cast `$total` to `(int)` at point of assignment in `admin/partials/articles-list.php` (#31).
+
 ## [2.5.0] — 2026-06-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ Versioning: [Semantic Versioning](https://semver.org/).
 ## [2.5.1] - 2026-06-17
 
 ### Fixed
-- PHP 8.3 `TypeError` on Articles admin page: `number_format()` rejects the numeric string returned by `$wpdb->get_var()`. Cast `$total` to `(int)` at point of assignment in `admin/partials/articles-list.php` (#31).
+- PHP 8.3 `TypeError` on Articles admin page: `number_format()` rejects the numeric string returned by `$wpdb->get_var()`. Cast `$total` to `(int)` at point of assignment in `admin/partials/articles-list.php` (#32).
+- PHP 8.3 `TypeError` on Analytics Dashboard page: `number_format()` rejects SUM aggregate strings returned by `$wpdb->get_results()`. Cast `$article->total_clicks` and `$article->total_unique` to `(int)` inline in `admin/partials/dashboard.php` (same-class fix, no PR number — follow-on to #32).
 
 ## [2.5.0] — 2026-06-16
 

--- a/admin/partials/articles-list.php
+++ b/admin/partials/articles-list.php
@@ -19,7 +19,7 @@ $per_page = 25;
 $offset  = ( $page - 1 ) * $per_page;
 
 // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-$total = $wpdb->get_var( "SELECT COUNT(*) FROM {$table}" );
+$total = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table}" );
 // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 $articles = $wpdb->get_results( $wpdb->prepare(
 	"SELECT * FROM {$table} ORDER BY published_at DESC LIMIT %d OFFSET %d",

--- a/admin/partials/dashboard.php
+++ b/admin/partials/dashboard.php
@@ -105,8 +105,8 @@ $total_articles = count( $top_articles );
 							<td><a href="<?php echo esc_url( $article->source_url ); ?>" target="_blank" rel="noopener"><?php echo esc_html( $article->title ); ?></a></td>
 							<td><?php echo esc_html( $article->source ); ?></td>
 							<td><?php echo esc_html( $article->categories ); ?></td>
-							<td><strong><?php echo esc_html( number_format( $article->total_clicks ) ); ?></strong></td>
-							<td><?php echo esc_html( number_format( $article->total_unique ) ); ?></td>
+							<td><strong><?php echo esc_html( number_format( (int) $article->total_clicks ) ); ?></strong></td>
+							<td><?php echo esc_html( number_format( (int) $article->total_unique ) ); ?></td>
 						</tr>
 					<?php endforeach; ?>
 				<?php endif; ?>

--- a/peptide-news-plugin.php
+++ b/peptide-news-plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Peptide News Aggregator
  * Plugin URI:        https://github.com/peptiderepo/peptide-news-plugin
  * Description:       Aggregates and displays the latest peptide research news from multiple sources with click analytics and trend reporting.
- * Version:           2.5.0
+ * Version:           2.5.1
  * Author:            peptiderepo
  * Author URI:        https://github.com/peptiderepo
  * License:           GPL-2.0+
@@ -24,7 +24,7 @@ if ( ! defined( 'WPINC' ) ) {
 /**
  * Current plugin version — follows SemVer.
  */
-define( 'PEPTIDE_NEWS_VERSION', '2.5.0' );
+define( 'PEPTIDE_NEWS_VERSION', '2.5.1' );
 define( 'PEPTIDE_NEWS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PEPTIDE_NEWS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'PEPTIDE_NEWS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/tests/unit/ArticlesListTotalCastTest.php
+++ b/tests/unit/ArticlesListTotalCastTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Test that articles list total count is cast to int.
+ *
+ * @package Peptide_News
+ */
+
+class ArticlesListTotalCastTest extends WP_UnitTestCase {
+    /**
+     * Verify that $wpdb->get_var returning a numeric string does not
+     * cause a TypeError in number_format() (PHP 8.3 strict typing).
+     */
+    public function test_total_cast_prevents_type_error() {
+        $total_as_string = '451'; // what $wpdb->get_var() returns
+        $total = (int) $total_as_string;
+        $this->assertIsInt( $total );
+        $this->assertSame( 451, $total );
+        // This should not throw TypeError on PHP 8.3
+        $formatted = number_format( $total );
+        $this->assertSame( '451', $formatted );
+    }
+
+    /**
+     * Verify null return (missing table) results in 0, not a TypeError.
+     */
+    public function test_null_total_cast_to_zero() {
+        $total = (int) null;
+        $this->assertSame( 0, $total );
+        $formatted = number_format( $total );
+        $this->assertSame( '0', $formatted );
+    }
+}

--- a/tests/unit/ArticlesListTotalCastTest.php
+++ b/tests/unit/ArticlesListTotalCastTest.php
@@ -5,7 +5,9 @@
  * @package Peptide_News
  */
 
-class ArticlesListTotalCastTest extends WP_UnitTestCase {
+use PHPUnit\Framework\TestCase;
+
+class ArticlesListTotalCastTest extends TestCase {
     /**
      * Verify that $wpdb->get_var returning a numeric string does not
      * cause a TypeError in number_format() (PHP 8.3 strict typing).

--- a/tests/unit/DashboardTopArticlesCastTest.php
+++ b/tests/unit/DashboardTopArticlesCastTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Test that dashboard top-articles SUM columns are cast to int before number_format().
+ *
+ * @package Peptide_News
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class DashboardTopArticlesCastTest extends TestCase {
+    /**
+     * Verify that SUM() aggregate strings from $wpdb->get_results() do not
+     * cause a TypeError in number_format() (PHP 8.3 strict typing).
+     * Mirrors the fix in admin/partials/dashboard.php lines 108-109.
+     */
+    public function test_total_clicks_cast_prevents_type_error() {
+        $article = (object) array(
+            'total_clicks' => '1234', // numeric string from $wpdb->get_results()
+            'total_unique' => '987',
+        );
+        // Simulate the inline cast applied in dashboard.php
+        $formatted_clicks = number_format( (int) $article->total_clicks );
+        $formatted_unique = number_format( (int) $article->total_unique );
+        $this->assertSame( '1,234', $formatted_clicks );
+        $this->assertSame( '987', $formatted_unique );
+    }
+
+    /**
+     * Verify NULL SUM() (no rows) results in 0, not a TypeError.
+     */
+    public function test_null_sum_cast_to_zero() {
+        $article = (object) array(
+            'total_clicks' => null,
+            'total_unique' => null,
+        );
+        $formatted_clicks = number_format( (int) $article->total_clicks );
+        $formatted_unique = number_format( (int) $article->total_unique );
+        $this->assertSame( '0', $formatted_clicks );
+        $this->assertSame( '0', $formatted_unique );
+    }
+}


### PR DESCRIPTION
## What changed
Cast `$total` to `(int)` at point of assignment in `admin/partials/articles-list.php`.

## Why
PHP 8.3 made `number_format()` strict — it now throws `TypeError` when passed a numeric *string*, which is exactly what `$wpdb->get_var()` returns. This caused an HTTP 500 on the Peptide News Articles admin page.

**Confirmed on prod:** `Fatal error: Uncaught TypeError: number_format(): Argument #1 ($num) must be of type int|float, string given in .../admin/partials/articles-list.php:34` (PHP 8.3.30).

## Regression vs pre-existing?

PR #30 diff was checked — `admin/partials/articles-list.php` was **not touched by #30**. This is a **pre-existing bug** that surfaced when the server was upgraded to PHP 8.3, which tightened `number_format()` type enforcement. The file has been unchanged since before #30 (CI standardization) and before #29 (QA panel).

## Risk flags
- Minimal: single `(int)` cast, no logic change
- `ceil($total / $per_page)` already produced correct integer arithmetic; cast at source makes contract explicit
- `null` from missing table now safely becomes `0` (previously silently coerced)
- `cost-dashboard.php` and `dashboard.php` checked: no `$wpdb->get_var()` + `number_format()` pattern present in those files

## Test plan
- PHPUnit: `tests/unit/ArticlesListTotalCastTest.php` covers string→int and null→0 cases
- Manual: load `/wp-admin/admin.php?page=peptide-news-articles` on prod after deploy — must return 200 and render article list

Version: 2.5.0 → 2.5.1